### PR TITLE
Add thread safety ( guard against collection has changed errors)

### DIFF
--- a/src/InMemoryLogger.cs
+++ b/src/InMemoryLogger.cs
@@ -45,10 +45,21 @@
 
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
     {
-      lock(this.logLines)
+      var message=formatter(state, exception);
+      lock (this.logLines)
       {
-        this.logLines.Add((logLevel, exception, formatter(state, exception)));
+        this.logLines.Add((logLevel, exception,message ));
+      }
+      if (logLevel>=MinimumEventSeverity)
+      {
+        LoggedEvent?.Invoke(this,(logLevel, exception,message ));
       }
     }
+    /// <summary>
+    /// This event handler is called synchronously inside the logging call.  Take great care when
+    /// setting the minimum event severity low, or taking significant time within the event handler
+    /// </summary>
+    public LogLevel MinimumEventSeverity { get; set; } = LogLevel.None;
+    public event EventHandler<(LogLevel Level, Exception Exception, string Message)> LoggedEvent;
   }
 }

--- a/src/InMemoryLogger.cs
+++ b/src/InMemoryLogger.cs
@@ -22,7 +22,7 @@
 
     public InMemLoggerProvider(InMemoryLogger logger) => this.logger = logger;
 
-    public ILogger CreateLogger(string categoryName) => logger;
+    public ILogger CreateLogger(string categoryName) => this.logger;
 
     public void Dispose() { }
   }
@@ -31,13 +31,13 @@
   {
     private readonly List<(LogLevel, Exception, string)> logLines = new List<(LogLevel, Exception, string)>();
 
-    public IEnumerable<(LogLevel Level, Exception Exception, string Message)> RecordedLogs => this.logLines.AsReadOnly();
-    public IEnumerable<(LogLevel Level, Exception Exception, string Message)> RecordedTraceLogs => this.logLines.Where(l => l.Item1 == LogLevel.Trace);
-    public IEnumerable<(LogLevel Level, Exception Exception, string Message)> RecordedDebugLogs => this.logLines.Where(l => l.Item1 == LogLevel.Debug);
-    public IEnumerable<(LogLevel Level, Exception Exception, string Message)> RecordedInformationLogs => this.logLines.Where(l => l.Item1 == LogLevel.Information);
-    public IEnumerable<(LogLevel Level, Exception Exception, string Message)> RecordedWarningLogs => this.logLines.Where(l => l.Item1 == LogLevel.Warning);
-    public IEnumerable<(LogLevel Level, Exception Exception, string Message)> RecordedErrorLogs => this.logLines.Where(l => l.Item1 == LogLevel.Error);
-    public IEnumerable<(LogLevel Level, Exception Exception, string Message)> RecordedCriticalLogs => this.logLines.Where(l => l.Item1 == LogLevel.Critical);
+    public IEnumerable<(LogLevel Level, Exception Exception, string Message)> RecordedLogs { get { lock (this.logLines) { return this.logLines.ToList(); } } }
+    public IEnumerable<(LogLevel Level, Exception Exception, string Message)> RecordedTraceLogs { get { lock (this.logLines) { return this.logLines.Where(l => l.Item1 == LogLevel.Trace).ToList(); } } }
+    public IEnumerable<(LogLevel Level, Exception Exception, string Message)> RecordedDebugLogs { get { lock (this.logLines) { return this.logLines.Where(l => l.Item1 == LogLevel.Debug).ToList(); } } }
+    public IEnumerable<(LogLevel Level, Exception Exception, string Message)> RecordedInformationLogs { get { lock (this.logLines) { return this.logLines.Where(l => l.Item1 == LogLevel.Information).ToList(); } } }
+    public IEnumerable<(LogLevel Level, Exception Exception, string Message)> RecordedWarningLogs { get { lock (this.logLines) { return this.logLines.Where(l => l.Item1 == LogLevel.Warning).ToList(); } } }
+    public IEnumerable<(LogLevel Level, Exception Exception, string Message)> RecordedErrorLogs { get { lock (this.logLines) { return this.logLines.Where(l => l.Item1 == LogLevel.Error).ToList(); } } }
+    public IEnumerable<(LogLevel Level, Exception Exception, string Message)> RecordedCriticalLogs { get { lock (this.logLines) { return this.logLines.Where(l => l.Item1 == LogLevel.Critical).ToList(); } } }
 
     public IDisposable BeginScope<TState>(TState state) => null;
 
@@ -45,7 +45,10 @@
 
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
     {
-      this.logLines.Add((logLevel, exception, formatter(state, exception)));
+      lock(this.logLines)
+      {
+        this.logLines.Add((logLevel, exception, formatter(state, exception)));
+      }
     }
   }
 }

--- a/tests/InMemoryLogger_should.cs
+++ b/tests/InMemoryLogger_should.cs
@@ -13,7 +13,7 @@ namespace InMemLogger.Tests
     private readonly InMemoryLogger inMemLogger;
 
     public static IEnumerable<object[]> LogLevels() =>
-      ((IEnumerable<LogLevel>) Enum.GetValues(typeof(LogLevel))).Select(v => new object[] { v });
+      ((IEnumerable<LogLevel>)Enum.GetValues(typeof(LogLevel))).Select(v => new object[] { v });
 
     public InMemoryLogger_should()
     {
@@ -44,5 +44,27 @@ namespace InMemLogger.Tests
 
       Assert.Contains(this.inMemLogger.RecordedLogs, l => l.Level == level && l.Exception == expected);
     }
+
+    [Theory]
+    [MemberData(nameof(LogLevels))]
+    public void check_events(LogLevel level)
+    {
+      var expected = new Exception();
+      int numEvents = 0;
+      this.inMemLogger.MinimumEventSeverity = level;
+      this.inMemLogger.LoggedEvent += (o, e) =>
+      {
+        ++numEvents;
+        Assert.True(e.Level >= level);
+      };
+      for (var testLevel = LogLevel.Trace; testLevel < LogLevel.None; ++testLevel)
+      {
+        this.ilogger.Log(testLevel, expected, "");
+      }
+
+      Assert.True(this.inMemLogger.RecordedLogs.Count() == LogLevel.None - LogLevel.Trace );
+      Assert.True(numEvents == LogLevel.None-level);
+    }
+
   }
 }


### PR DESCRIPTION
Upside: there won't be an error is something is logged whilst someone is enumerating the results of (e.g.) RecordedLogs.

Downside: it has to make a copy of the list.  However it's only the list object that will be duplicated, the actual tuples in the list won't be. 